### PR TITLE
A CI job tests the PyPI package's build

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,0 +1,18 @@
+name: Continuous integration
+
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - main
+
+jobs:
+  test_pypi_package_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Test the build
+        run: python3 .github/workflows/test_pypi_package_build.py

--- a/.github/workflows/test_pypi_package_build.py
+++ b/.github/workflows/test_pypi_package_build.py
@@ -1,0 +1,18 @@
+#!/bin/python3
+
+from os import system
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# This script is meant to run on GitHub's virtual machine ubuntu-latest in a CI
+# workflow. It builds the PyPI package and installs it to ensure the
+# installation works. However, the script does not upload the package to PyPI.
+
+system(f"python3 {_REPO_ROOT}/setup.py sdist")
+
+latest_dist = list((_REPO_ROOT/"dist").glob("repr_rw-*.tar.gz"))[-1]
+
+system(f"pip3 install --no-cache-dir {latest_dist}")


### PR DESCRIPTION
The new CI workflow job builds the PyPI package and installs it on GitHub's virtual machine `ubuntu-latest` to ensure the installation works. However, the job does not upload the package to PyPI.