### PR TITLE
`syspathmodif` version incremented to `1.1.2`

### DIFF
--- a/.github/workflows/test_pypi_package_build.py
+++ b/.github/workflows/test_pypi_package_build.py
@@ -1,5 +1,3 @@
-#!/bin/python3
-
 from os import system
 from pathlib import Path
 

--- a/demos/demo_read.py
+++ b/demos/demo_read.py
@@ -26,7 +26,7 @@ importations = {
 	# Importing Point from its module requires the path to
 	# directory demo_package, which is not included in sys.path.
 	"from point import Point": _REPO_ROOT/"demo_package",
-	# Since pathlib is a built-in module, its importation
+	# Since pathlib is a standard module, its importation
 	# does not require a path.
 	"from pathlib import PosixPath, WindowsPath": None
 }

--- a/repr_rw/repr_rw.py
+++ b/repr_rw/repr_rw.py
@@ -1,5 +1,6 @@
 import re
 
+# strath is a dependency of syspathmodif.
 from strath import\
 	ensure_path_is_pathlib
 from syspathmodif import\

--- a/repr_rw/repr_rw.py
+++ b/repr_rw/repr_rw.py
@@ -38,8 +38,8 @@ def read_reprs(file_path, importations=None, ignore_except=False):
 	need to provide a dictionary mapping the appropriate import statements
 	(keys, type str) to the path (value, type str or pathlib.Path) to the
 	parent directory of the class's module or package. However, if the imported
-	class is from a built-in module or the standard library, set the value to
-	None. Statements that are not importations will not be executed.
+	class is from the standard library, set the value to None. Statements that
+	are not importations will not be executed.
 
 	Parameters:
 		file_path (str or pathlib.Path): the path to a text file that contains

--- a/repr_rw/repr_rw.py
+++ b/repr_rw/repr_rw.py
@@ -1,7 +1,7 @@
-from pathlib import\
-	Path
 import re
 
+from strath import\
+	ensure_path_is_pathlib
 from syspathmodif import\
 	sp_append,\
 	sp_remove
@@ -14,18 +14,6 @@ _NEW_LINE = "\n"
 
 _REGEX_IMPORT = "import .+"
 _REGEX_FROM_IMPORT = "from .+ import .+"
-
-
-def _ensure_is_path(obj):
-	if isinstance(obj, Path):
-		return obj
-
-	elif isinstance(obj, str):
-		return Path(obj)
-
-	else:
-		raise TypeError(
-			"An argument of type str or pathlib.Path is expected.")
 
 
 def _is_import_statement(some_str):
@@ -82,7 +70,7 @@ def read_reprs(file_path, importations=None, ignore_except=False):
 				if was_path_appended:
 					sp_remove(path)
 
-	file_path = _ensure_is_path(file_path)
+	file_path = ensure_path_is_pathlib(file_path, False)
 
 	with file_path.open(mode=_MODE_R, encoding=_ENCODING_UTF8) as file:
 		for obj_repr in file: # The iterator yields one line at the time.
@@ -109,7 +97,7 @@ def write_reprs(file_path, objs):
 	Raises:
 		TypeError: if argument file_path is not of type str or pathlib.Path.
 	"""
-	file_path = _ensure_is_path(file_path)
+	file_path = ensure_path_is_pathlib(file_path, False)
 
 	with file_path.open(mode=_MODE_W, encoding=_ENCODING_UTF8) as file:
 		for obj in objs:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-syspathmodif==1.1.0
+syspathmodif==1.1.2


### PR DESCRIPTION
* Library `strath`, a dependency of `syspathmodif`, converts `str` paths to `pathlib.Path` instances.
* Mentions of built-in content were removed because built-in content is available without import.