### PR TITLE
`read_reprs`: imports must match regex `"from .+ import .+"`

### DIFF
--- a/repr_rw/repr_rw.py
+++ b/repr_rw/repr_rw.py
@@ -21,9 +21,10 @@ def _is_valid_import_statement(some_str):
 	return regex_match is not None
 
 
-def _raise_import_statement_value_error(bad_import):
-	raise ValueError(f"Import statements must match regex \""
-		+ _REGEX_FROM_IMPORT + "\". Recieved \"" + bad_import + "\".")
+def _raise_import_statement_value_error(importation):
+	if not _is_valid_import_statement(importation):
+		raise ValueError(f"Import statements must match regex \""
+			+ _REGEX_FROM_IMPORT + "\". Recieved \"" + importation + "\".")
 
 
 def read_reprs(file_path, importations=None, ignore_except=False):
@@ -68,8 +69,7 @@ def read_reprs(file_path, importations=None, ignore_except=False):
 	"""
 	if importations is not None:
 		for importation, path in importations.items():
-			if not _is_valid_import_statement(importation):
-				_raise_import_statement_value_error(importation)
+			_raise_import_statement_value_error(importation)
 
 			was_path_appended = sp_append(path)
 			exec(importation)

--- a/repr_rw/repr_rw.py
+++ b/repr_rw/repr_rw.py
@@ -13,18 +13,12 @@ _MODE_R = "r"
 _MODE_W = "w"
 _NEW_LINE = "\n"
 
-_REGEX_IMPORT = "import .+"
 _REGEX_FROM_IMPORT = "from .+ import .+"
 
 
-def _is_import_statement(some_str):
-	if re.match(_REGEX_IMPORT, some_str) is not None:
-		return True
-
-	if re.match(_REGEX_FROM_IMPORT, some_str) is not None:
-		return True
-
-	return False
+def _is_valid_import_statement(some_str):
+	regex_match = re.match(_REGEX_FROM_IMPORT, some_str)
+	return regex_match is not None
 
 
 def read_reprs(file_path, importations=None, ignore_except=False):
@@ -38,10 +32,11 @@ def read_reprs(file_path, importations=None, ignore_except=False):
 	need to provide a dictionary mapping the appropriate import statements
 	(keys, type str) to the path (value, type str or pathlib.Path) to the
 	parent directory of the class's module or package. However, if the imported
-	class is from the standard library, set the value to None. Statements that
-	are not importations will not be executed.
+	class is from the standard library, set the value to None. Only import
+	statements matching regular expression "from .+ import .+" will be
+	executed.
 
-	Parameters:
+	Args:
 		file_path (str or pathlib.Path): the path to a text file that contains
 			object representations.
 		importations (dict): the import statements (keys, type str) and the
@@ -64,7 +59,7 @@ def read_reprs(file_path, importations=None, ignore_except=False):
 	"""
 	if importations is not None:
 		for importation, path in importations.items():
-			if _is_import_statement(importation):
+			if _is_valid_import_statement(importation):
 				was_path_appended = sp_append(path)
 				exec(importation)
 
@@ -89,7 +84,7 @@ def write_reprs(file_path, objs):
 	string returned by function repr. If the file already exists, this function
 	overwrites it.
 
-	Parameters:
+	Args:
 		file_path (str or pathlib.Path): the path to the text file that will
 			contain the object representations.
 		objs (generator, list, set or tuple): the objects whose representation

--- a/repr_rw/repr_rw.py
+++ b/repr_rw/repr_rw.py
@@ -14,6 +14,8 @@ _MODE_W = "w"
 _NEW_LINE = "\n"
 
 _REGEX_FROM_IMPORT = "from .+ import .+"
+_NON_MATCHING_IMPORT_MSG =\
+	f"Import statements must match regex \"{_REGEX_FROM_IMPORT}\"."
 
 
 def _is_valid_import_statement(some_str):
@@ -62,12 +64,14 @@ def read_reprs(file_path, importations=None, ignore_except=False):
 	"""
 	if importations is not None:
 		for importation, path in importations.items():
-			if _is_valid_import_statement(importation):
-				was_path_appended = sp_append(path)
-				exec(importation)
+			if not _is_valid_import_statement(importation):
+				raise ValueError(_NON_MATCHING_IMPORT_MSG)
 
-				if was_path_appended:
-					sp_remove(path)
+			was_path_appended = sp_append(path)
+			exec(importation)
+
+			if was_path_appended:
+				sp_remove(path)
 
 	file_path = ensure_path_is_pathlib(file_path, False)
 

--- a/repr_rw/repr_rw.py
+++ b/repr_rw/repr_rw.py
@@ -50,9 +50,12 @@ def read_reprs(file_path, importations=None, ignore_except=False):
 		an object recreated from its representation.
 
 	Raises:
-		FileNotFoundError: if argument file_path does not exist.
-		ModuleNotFoundError: if an importation statement is missing or
-			contains a fault.
+		FileNotFoundError: if the file indicated by argument file_path does
+			not exist.
+		ImportError: if an import statement contains a fault.
+		ModuleNotFoundError: if an imported module cannot be found. The
+			corresponding value in argument importations may be incorrect.
+		NameError: if a required class was not imported.
 		TypeError: if argument file_path is not of type str or pathlib.Path.
 		Exception: any exception raised upon the parsing of an object
 			representation if ignore_except is False.

--- a/repr_rw/repr_rw.py
+++ b/repr_rw/repr_rw.py
@@ -14,13 +14,16 @@ _MODE_W = "w"
 _NEW_LINE = "\n"
 
 _REGEX_FROM_IMPORT = "from .+ import .+"
-_NON_MATCHING_IMPORT_MSG =\
-	f"Import statements must match regex \"{_REGEX_FROM_IMPORT}\"."
 
 
 def _is_valid_import_statement(some_str):
 	regex_match = re.match(_REGEX_FROM_IMPORT, some_str)
 	return regex_match is not None
+
+
+def _raise_import_statement_value_error(bad_import):
+	raise ValueError(f"Import statements must match regex \""
+		+ _REGEX_FROM_IMPORT + "\". Recieved \"" + bad_import + "\".")
 
 
 def read_reprs(file_path, importations=None, ignore_except=False):
@@ -34,9 +37,8 @@ def read_reprs(file_path, importations=None, ignore_except=False):
 	need to provide a dictionary mapping the appropriate import statements
 	(keys, type str) to the path (value, type str or pathlib.Path) to the
 	parent directory of the class's module or package. However, if the imported
-	class is from the standard library, set the value to None. Only import
-	statements matching regular expression "from .+ import .+" will be
-	executed.
+	class is from the standard library, set the value to None. All import
+	statements must match regular expression "from .+ import .+".
 
 	Args:
 		file_path (str or pathlib.Path): the path to a text file that contains
@@ -59,13 +61,15 @@ def read_reprs(file_path, importations=None, ignore_except=False):
 			corresponding value in argument importations may be incorrect.
 		NameError: if a required class was not imported.
 		TypeError: if argument file_path is not of type str or pathlib.Path.
+		ValueError: if an import statement does not match regular expression
+			"from .+ import .+".
 		Exception: any exception raised upon the parsing of an object
 			representation if ignore_except is False.
 	"""
 	if importations is not None:
 		for importation, path in importations.items():
 			if not _is_valid_import_statement(importation):
-				raise ValueError(_NON_MATCHING_IMPORT_MSG)
+				_raise_import_statement_value_error(importation)
 
 			was_path_appended = sp_append(path)
 			exec(importation)


### PR DESCRIPTION
Imports matching `"import .+"` are useless as they cannot import a class. Unallowed import statements cause a `ValueError`.