### PR TITLE
Function `read_reprs` handles the paths with `SysPathBundle`

### DIFF
--- a/demos/demo_read.py
+++ b/demos/demo_read.py
@@ -28,12 +28,17 @@ importations = [
 	# Built-in types tuple and list do not require a path.
 ]
 paths = (_REPO_ROOT, _REPO_ROOT/"demo_package")
+
+
+# In this example, read_reprs handles the paths.
 obj_generator = read_reprs(obj_path, importations, paths)
 
 print("Objects read:")
 for obj in obj_generator:
 	print(f"{obj} {type(obj)}")
 
+
+# In this example, the paths are handled out of read_reprs.
 obj_generator = None
 with SysPathBundle(paths):
 	obj_generator = read_reprs(obj_path, importations)

--- a/demos/demo_read.py
+++ b/demos/demo_read.py
@@ -19,18 +19,13 @@ if not obj_path.exists():
 	print("Run demos/demo_write.py to generate the file that this script needs.\n")
 	sys.exit(1)
 
-importations = {
-	# Importing Ajxo from demo_package requires the path to
-	# the repository's root, which is not included in sys.path.
-	"from demo_package import Ajxo": _REPO_ROOT,
-	# Importing Point from its module requires the path to
-	# directory demo_package, which is not included in sys.path.
-	"from point import Point": _REPO_ROOT/"demo_package",
-	# Since pathlib is a standard module, its importation
-	# does not require a path.
-	"from pathlib import PosixPath, WindowsPath": None
-}
-obj_generator = read_reprs(obj_path, importations)
+importations = [
+	"from demo_package import Ajxo",
+	"from point import Point",
+	"from pathlib import PosixPath, WindowsPath"
+]
+paths = [_REPO_ROOT, _REPO_ROOT/"demo_package"]
+obj_generator = read_reprs(obj_path, importations, paths)
 
 print("Objects read:")
 for obj in obj_generator:

--- a/demos/demo_read.py
+++ b/demos/demo_read.py
@@ -22,7 +22,9 @@ if not obj_path.exists():
 importations = [
 	"from demo_package import Ajxo",
 	"from point import Point",
+	# Standard package pathlib does not require a path.
 	"from pathlib import PosixPath, WindowsPath"
+	# Built-in types tuple and list do not require a path.
 ]
 paths = [_REPO_ROOT, _REPO_ROOT/"demo_package"]
 obj_generator = read_reprs(obj_path, importations, paths)

--- a/demos/demo_read.py
+++ b/demos/demo_read.py
@@ -2,7 +2,8 @@ from pathlib import Path
 import sys
 from syspathmodif import\
 	sp_append,\
-	sp_remove
+	sp_remove,\
+	SysPathBundle
 
 _LOCAL_DIR = Path(__file__).parent.resolve()
 _REPO_ROOT = _LOCAL_DIR.parent
@@ -26,9 +27,18 @@ importations = [
 	"from pathlib import PosixPath, WindowsPath"
 	# Built-in types tuple and list do not require a path.
 ]
-paths = [_REPO_ROOT, _REPO_ROOT/"demo_package"]
+paths = (_REPO_ROOT, _REPO_ROOT/"demo_package")
 obj_generator = read_reprs(obj_path, importations, paths)
 
 print("Objects read:")
 for obj in obj_generator:
 	print(f"{obj} {type(obj)}")
+
+obj_generator = None
+with SysPathBundle(paths):
+	obj_generator = read_reprs(obj_path, importations)
+
+if obj_generator is not None:
+	print("\nObjects read:")
+	for obj in obj_generator:
+		print(f"{obj} {type(obj)}")

--- a/demos/demo_write.py
+++ b/demos/demo_write.py
@@ -22,7 +22,8 @@ objs = [
 	Point(29, 7),
 	Point(461.28, 37.59),
 	Point(10.2, 83),
-	Path("some/directory/file.txt")
+	Path("some/directory/file.txt"),
+	(3.14159, "abc", 42, [1, 1, 2, 3, 5, 8, 13, 21])
 ]
 
 obj_path = _LOCAL_DIR/"objects.txt"

--- a/repr_rw/repr_rw.py
+++ b/repr_rw/repr_rw.py
@@ -38,6 +38,9 @@ def read_reprs(file_path, importations=None, paths=None):
 	statements and the paths to the parent directory of the imported classes'
 	module or package. All import statements must match regular expression
 	"from .+ import .+".
+	
+	However, you do not need to provide a path for standard and installed
+	packages.
 
 	Args:
 		file_path (str or pathlib.Path): the path to a text file that contains

--- a/repr_rw/repr_rw.py
+++ b/repr_rw/repr_rw.py
@@ -33,14 +33,18 @@ def read_reprs(file_path, importations=None, paths=None):
 	must be a string returned by function repr. Empty lines are ignored. Each
 	iteration of this generator yields one object.
 
-	Recreating objects requires to import their class unless they all are of a
+	Recreating objects requires to import their class unless they are of a
 	built-in type. For this purpose, you need to provide the necessary import
-	statements and the paths to the parent directory of the imported classes'
-	module or package. All import statements must match regular expression
-	"from .+ import .+".
-	
-	However, you do not need to provide a path for standard and installed
-	packages.
+	statements as character strings. All import statements must match regular
+	expression "from .+ import .+".
+
+	The imported classes' package or module must be accessible for importation.
+	It is already the case for standard and installed packages. For classes
+	from other sources, you need to include the path to its package's or
+	module's parent directory in list sys.path. If you provide the required
+	paths to this generator, it will add them to sys.path, perform the imports
+	and remove the paths from sys.path. If, instead, you choose to handle the
+	paths out of this generator, you should not provide any path.
 
 	Args:
 		file_path (str or pathlib.Path): the path to a text file that contains

--- a/repr_rw/repr_rw.py
+++ b/repr_rw/repr_rw.py
@@ -86,7 +86,10 @@ def read_reprs(file_path, importations=None, paths=None):
 	file_path = ensure_path_is_pathlib(file_path, False)
 
 	with file_path.open(mode=_MODE_R, encoding=_ENCODING_UTF8) as file:
-		for obj_repr in file: # The iterator yields one line at the time.
+		for obj_repr in file:
+			# The iterator yields one line at the time, including \n.
+			obj_repr = obj_repr.strip()
+
 			if len(obj_repr) >= 1:
 				yield eval(obj_repr)
 

--- a/repr_rw/repr_rw.py
+++ b/repr_rw/repr_rw.py
@@ -33,19 +33,17 @@ def read_reprs(file_path, importations=None, paths=None):
 	must be a string returned by function repr. Empty lines are ignored. Each
 	iteration of this generator yields one object.
 
-	Recreating objects requires to import their class. For this purpose, you
-	need to provide the appropriate import statements and the paths to the
-	parent directory of the classes' module or package. All import statements
-	must match regular expression "from .+ import .+".
-	
-	However, you do not need to provide a path to an imported class's package
-	or module if it is from the standard library or a project dependency.
+	Recreating objects requires to import their class unless they all are of a
+	built-in type. For this purpose, you need to provide the necessary import
+	statements and the paths to the parent directory of the imported classes'
+	module or package. All import statements must match regular expression
+	"from .+ import .+".
 
 	Args:
 		file_path (str or pathlib.Path): the path to a text file that contains
 			object representations.
-		importations (generator, list, set or tuple): class import statements
-			(str). Defaults to None.
+		importations (generator, list, set or tuple):
+			class import statements (str). Defaults to None.
 		paths (generator, list, set or tuple): the paths (str or pathlib.Path)
 			to the imported classes. Defaults to None.
 
@@ -55,11 +53,12 @@ def read_reprs(file_path, importations=None, paths=None):
 	Raises:
 		FileNotFoundError: if the file indicated by argument file_path does
 			not exist.
-		ImportError: if an import statement contains a fault.
-		ModuleNotFoundError: if an imported module cannot be found. The
-			corresponding value in argument importations may be incorrect.
+		ImportError: if an import statement is incorrect.
+		ModuleNotFoundError: if an imported class' module or package cannot
+			be found. An item in argument paths may be incorrect.
 		NameError: if a required class was not imported.
-		TypeError: if argument file_path is not of type str or pathlib.Path.
+		TypeError: if argument file_path or an item in argument paths is not
+			of type str or pathlib.Path.
 		ValueError: if an import statement does not match regular expression
 			"from .+ import .+".
 		Exception: any exception raised upon the parsing of an object

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-syspathmodif==1.1.2
+syspathmodif==1.2.0


### PR DESCRIPTION
* Easier interface: separate lists for the import statements and the paths.
* The user can handle the paths out of `read_reprs`.
* Parameter `ignore_except` removed.
* `read_reprs` strips the object representations.
* Built-in types `tuple` and `list` in the demos.