### PR TITLE
Package content exposition

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,9 +1,0 @@
-from .repr_rw import\
-	read_reprs,\
-	write_reprs
-
-
-__all__ = [
-	read_reprs.__name__,
-	write_reprs.__name__
-]

--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,9 @@
 from .repr_rw import\
 	read_reprs,\
 	write_reprs
+
+
+__all__ = [
+	read_reprs.__name__,
+	write_reprs.__name__
+]

--- a/demo_package/__init__.py
+++ b/demo_package/__init__.py
@@ -1,2 +1,5 @@
 from .ajxo import Ajxo
 from .point import Point
+
+# This package does not declare __all__ because the
+# reading demo needs modules ajxo and point to be public.

--- a/demo_package/ajxo.py
+++ b/demo_package/ajxo.py
@@ -7,7 +7,7 @@ class Ajxo:
 
 	def __repr__(self):
 		return self.__class__.__name__\
-			+ "(" + repr(self.a) + ", " + repr(self.b) + ")"
+			+ f"({repr(self.a)}, {repr(self.b)})"
 
 
 __all__ = [Ajxo.__name__]

--- a/demo_package/ajxo.py
+++ b/demo_package/ajxo.py
@@ -8,3 +8,6 @@ class Ajxo:
 	def __repr__(self):
 		return self.__class__.__name__\
 			+ "(" + repr(self.a) + ", " + repr(self.b) + ")"
+
+
+__all__ = [Ajxo.__name__]

--- a/demo_package/point.py
+++ b/demo_package/point.py
@@ -6,7 +6,7 @@ class Point:
 
 	def __repr__(self):
 		return self.__class__.__name__\
-			+ "(" + str(self._x) + ", " + str(self._y) + ")"
+			+ f"({str(self._x)}, {str(self._y)})"
 
 	@property
 	def x(self):

--- a/demo_package/point.py
+++ b/demo_package/point.py
@@ -15,3 +15,6 @@ class Point:
 	@property
 	def y(self):
 		return self._y
+
+
+__all__ = [Point.__name__]

--- a/repr_rw/__init__.py
+++ b/repr_rw/__init__.py
@@ -1,3 +1,9 @@
 from .repr_rw import\
 	read_reprs,\
 	write_reprs
+
+
+__all__ = [
+	read_reprs.__name__,
+	write_reprs.__name__
+]

--- a/repr_rw/repr_rw.py
+++ b/repr_rw/repr_rw.py
@@ -1,3 +1,5 @@
+# __all__ declared at the module's end
+
 import re
 
 # strath is a dependency of syspathmodif.
@@ -114,3 +116,9 @@ def write_reprs(file_path, objs):
 	with file_path.open(mode=_MODE_W, encoding=_ENCODING_UTF8) as file:
 		for obj in objs:
 			file.write(repr(obj) + _NEW_LINE)
+
+
+__all__ = [
+	read_reprs.__name__,
+	write_reprs.__name__
+]

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,6 @@ if __name__ == "__main__":
 		],
 		install_requires = _make_requirement_list(),
 		packages = setuptools.find_packages(
-			exclude=(".github", "demos", "demo_package",)),
+			exclude=(".github", "demo_package", "demos",)),
 		license = "MIT",
 		license_files = ("LICENSE",))


### PR DESCRIPTION
* The modules and package `repr_rw` declare `__all__`.
* `__all__` filled with attribute `.__name__`: less error-prone.
* The `__repr__` methods in `demo_package` use a formatted string.
* `__init__.py` at the repository's root removed because it was useless.