### PR TITLE
`syspathmodif` version incremented to `1.3.1`

### DIFF
--- a/demos/demo_read.py
+++ b/demos/demo_read.py
@@ -25,6 +25,7 @@ importations = [
 	"from point import Point",
 	# Standard package pathlib does not require a path.
 	"from pathlib import PosixPath, WindowsPath"
+	# SysPathBundle is imported in read_reprs' module.
 	# Built-in types tuple and list do not require a path.
 ]
 paths = (

--- a/demos/demo_write.py
+++ b/demos/demo_write.py
@@ -24,7 +24,7 @@ objs = [
 	Point(461.28, 37.59),
 	Point(10.2, 83),
 	Path("some/directory/file.txt"),
-	SysPathBundle((_REPO_ROOT, _LOCAL_DIR), True),
+	SysPathBundle((_REPO_ROOT, _LOCAL_DIR, _REPO_ROOT/"repr_rw"), True),
 	(3.14159, "abc", 42, [1, 1, 2, 3, 5, 8, 13, 21])
 ]
 

--- a/demos/demo_write.py
+++ b/demos/demo_write.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from syspathmodif import\
+	SysPathBundle,\
 	sp_append,\
 	sp_remove
 
@@ -23,6 +24,7 @@ objs = [
 	Point(461.28, 37.59),
 	Point(10.2, 83),
 	Path("some/directory/file.txt"),
+	SysPathBundle((_REPO_ROOT, _LOCAL_DIR), True),
 	(3.14159, "abc", 42, [1, 1, 2, 3, 5, 8, 13, 21])
 ]
 

--- a/repr_rw/repr_rw.py
+++ b/repr_rw/repr_rw.py
@@ -75,14 +75,13 @@ def read_reprs(file_path, importations=None, paths=None):
 	"""
 	if importations is not None:
 		if paths is not None:
-			bundle = SysPathBundle(paths)
+			bundle = SysPathBundle(paths, True)
 
 		for importation in importations:
 			_raise_import_statement_value_error(importation)
 			exec(importation)
 
 		if paths is not None:
-			bundle.clear()
 			del bundle
 
 	file_path = ensure_path_is_pathlib(file_path, False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-syspathmodif==1.2.0
+syspathmodif==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-syspathmodif==1.3.0
+syspathmodif==1.3.1


### PR DESCRIPTION
* `syspathmodif.SysPathBundle` has method `__repr__`.
* `SysPathBundle` instances can be cleared by the destructor.
* The demos use a `SysPathBundle` instance.