### PR TITLE
Reading representations without modifying `sys.path`

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -20,6 +20,8 @@ jobs:
         run: python3 demos/demo_write.py
       - name: Test the reading demo
         run: python3 demos/demo_read.py
+      - name: Test the reading demo with no paths given to read_reprs
+        run: python3 demos/demo_read_no_paths.py
   test_pypi_package_build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test_pypi_package_build.py
+++ b/.github/workflows/test_pypi_package_build.py
@@ -13,6 +13,6 @@ repo_root = Path(__file__).resolve().parents[2]
 
 system(f"python3 {repo_root}/setup.py sdist")
 
-latest_dist = list((repo_root/"dist").glob("repr_rw-*.tar.gz"))[-1]
+latest_dist = next((repo_root/"dist").glob("repr_rw-*.tar.gz"))
 
 system(f"pip3 install --no-cache-dir {latest_dist}")

--- a/.github/workflows/test_pypi_package_build.py
+++ b/.github/workflows/test_pypi_package_build.py
@@ -1,10 +1,13 @@
+"""
+This script is meant to run on GitHub's virtual machine ubuntu-latest in a CI
+workflow. It builds the PyPI package and installs it to ensure the
+installation works. However, the script does not upload the package to PyPI.
+"""
+
+
 from os import system
 from pathlib import Path
 
-
-# This script is meant to run on GitHub's virtual machine ubuntu-latest in a CI
-# workflow. It builds the PyPI package and installs it to ensure the
-# installation works. However, the script does not upload the package to PyPI.
 
 repo_root = Path(__file__).resolve().parents[2]
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,27 @@ itération de ce générateur produit un objet.
 Pour plus d'informations, consultez la documentation des fonctions et les démos
 dans le dépôt de code source.
 
+#### Importation de classes et modification de `sys.path`
+
+Recréer des objets requiert d'importer leur classe sauf s'ils sont d'un type
+natif (*built-in*). À cette fin, il faut fournir à `read_reprs` les
+instructions d'importation nécessaires en chaînes de caractères.
+
+Le paquet ou module des classes importées doit être accessible pour
+importation. C'est le cas des paquets standards et installés. Pour les classes
+d'autres sources, il faut inclure le chemin du dossier parent de leur paquet ou
+module dans la liste `sys.path`. Si des chemins sont fournis au générateur
+`read_reprs`, il les ajoute à `sys.path`, effectue les importations et enlève
+les chemins ajoutés de `sys.path`. L'utilisateur peut aussi modifier lui-même
+`sys.path` et ne pas fournir de chemins.
+
+Cependant, si un paquet ou module a été importé avant que `read_reprs` le
+fasse, inclure son chemin parent dans `sys.path` n'est pas nécessaire. Le
+dictionnaire `sys.modules` conserve les paquets et modules importés pour
+réutilisation, ce qui les rend disponibles dans tous les modules. Soyez prudent
+en profitant de cette fonctionnalité. Autrement, `read_reprs` risque de lever
+une exception `ModuleNotFoundError`.
+
 ### Dépendances
 
 Installez les dépendances avec cette commande.
@@ -72,6 +93,26 @@ generator yields one object.
 
 For more information, consult the functions' documentation and the demos in the
 source code repository.
+
+#### Importing classes and modifying `sys.path`
+
+Recreating objects requires to import their class unless they are of a built-in
+type. For this purpose, the user must provide the necessary import statements
+to `read_reprs` as character strings.
+
+The imported classes' package or module must be accessible for importation. It
+is already the case for standard and installed packages. For classes from other
+sources, the path to their package's or module's parent directory must be
+included in list `sys.path`. If paths are provided to generator `read_reprs`,
+it adds them to `sys.path`, performs the imports and removes the added paths
+from `sys.path`. The user can also modify `sys.path` themself and not provide
+any path.
+
+However, if a package or module has been imported before `read_reprs` does so,
+including its parent path in `sys.path` is not required. Dictionary
+`sys.modules` stores imported packages and modules for reuse, which makes them
+available in all modules. Be careful when benefitting from this feature.
+Otherwise, `read_reprs` may raise a `ModuleNotFoundError`.
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ is the case for standard and installed packages. For classes from other
 sources, the path to their package's or module's parent directory must be
 included in list `sys.path`. If paths are provided to generator `read_reprs`,
 it adds them to `sys.path`, performs the imports and removes the added paths
-from `sys.path`. If, instead, you modify sys.path out of this generator, you
+from `sys.path`. If, instead, you modify `sys.path` out of this generator, you
 should not provide any path to `read_reprs`.
 
 However, if a package or module has been imported before `read_reprs` does so,

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ instructions d'importation nécessaires en chaînes de caractères.
 
 Le paquet ou module des classes importées doit être accessible pour
 importation. C'est le cas des paquets standards et installés. Pour les classes
-d'autres sources, il faut inclure le chemin du dossier parent de leur paquet ou
-module dans la liste `sys.path`. Si des chemins sont fournis au générateur
-`read_reprs`, il les ajoute à `sys.path`, effectue les importations et enlève
-les chemins ajoutés de `sys.path`. Si l'utilisateur modifie lui-même
-`sys.path`, il ne devrait pas fournir de chemins à `read_reprs`.
+provenant d'autres sources, il faut inclure le chemin du dossier parent de leur
+paquet ou module dans la liste `sys.path`. Si des chemins sont fournis au
+générateur `read_reprs`, il les ajoute à `sys.path`, effectue les importations
+puis enlève les chemins ajoutés de `sys.path`. Si l'utilisateur modifie
+lui-même `sys.path`, il ne devrait pas fournir de chemins à `read_reprs`.
 
 Cependant, si un paquet ou module a été importé avant que `read_reprs` le
 fasse, inclure son chemin parent dans `sys.path` n'est pas nécessaire. Le
@@ -105,8 +105,8 @@ is the case for standard and installed packages. For classes from other
 sources, the path to their package's or module's parent directory must be
 included in list `sys.path`. If paths are provided to generator `read_reprs`,
 it adds them to `sys.path`, performs the imports and removes the added paths
-from `sys.path`. If, instead, you modify `sys.path` out of this generator, you
-should not provide any path to `read_reprs`.
+from `sys.path`. If, instead, you modify yourself `sys.path`, you should not
+provide any path to `read_reprs`.
 
 However, if a package or module has been imported before `read_reprs` does so,
 including its parent path in `sys.path` is not required. Dictionary

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ produit par cet autre script.
 python demos/demo_read.py
 ```
 
+Le script `demo_read_no_paths.py` montre comment la fonction `read_reprs` peut
+fonctionner sans ajouter de chemins à `sys.path`. Ce script aussi a besoin du
+fichier produit par `demo_write.py`.
+
+```
+python demos/demo_read_no_paths.py
+```
+
 ## ENGLISH
 
 This library writes Python object representations in a text file and reads the
@@ -87,4 +95,11 @@ that other script.
 
 ```
 python demos/demo_read.py
+```
+
+Script `demo_read_no_paths.py` shows how function `read_reprs` can work without
+adding paths to `sys.path`. This script too needs the file made by `demo_read.py`.
+
+```
+python demos/demo_read_no_paths.py
 ```

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## FRANÇAIS
 
-Cette bibliothèque écrit la représentation d'objets Python dans un fichier
+Cette bibliothèque écrit des représentations d'objets Python dans un fichier
 texte et lit le fichier pour recréer les objets. Une représentation d'objet
 est une chaîne de caractères renvoyée par la fonction `repr`.
 
 ### Contenu
 
-La fonction `write_reprs` écrit la représentation d'objets Python dans un
+La fonction `write_reprs` écrit des représentations d'objets Python dans un
 fichier texte. Chaque ligne du fichier est une représentation d'objet. Si le
 fichier spécifié existe déjà, cette fonction l'écrase.
 
@@ -82,11 +82,11 @@ function `repr`.
 
 ### Content
 
-Function `write_reprs` writes the representation of Python objects in a text
+Function `write_reprs` writes the representations of Python objects in a text
 file. Each line in the file is an object representation. If the specified file
 already exists, this function overwrites it.
 
-Generator `read_reprs` reads a text file that contains the representation of
+Generator `read_reprs` reads a text file that contains the representations of
 Python objects in order to recreate those objects. Each line in the file must
 be an object representation. Empty lines are ignored. Each iteration of this
 generator yields one object.

--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 
 ## FRANÇAIS
 
-Cette bibliothèque écrit des représentations d'objets Python dans un fichier
-texte et lit le fichier pour recréer les objets. Une représentation d'objet
-est une chaîne de caractères renvoyée par la fonction `repr`.
+Cette bibliothèque écrit des représentations d'objets dans un fichier texte et
+lit le fichier pour recréer les objets. Une représentation d'objet est une
+chaîne de caractères renvoyée par la fonction `repr`.
 
 ### Contenu
 
-La fonction `write_reprs` écrit des représentations d'objets Python dans un
-fichier texte. Chaque ligne du fichier est une représentation d'objet. Si le
-fichier spécifié existe déjà, cette fonction l'écrase.
+La fonction `write_reprs` écrit des représentations d'objets dans un fichier
+texte. Chaque ligne du fichier est une représentation d'objet. Si le fichier
+spécifié existe déjà, cette fonction l'écrase.
 
 Le générateur `read_reprs` lit un fichier texte contenant des représentations
-d'objets Python dans le but de recréer ces objets. Chaque ligne du fichier doit
-être une représentation d'objet. Les lignes vides sont ignorées. Chaque
-itération de ce générateur produit un objet.
+d'objets dans le but de recréer ces objets. Chaque ligne du fichier doit être
+une représentation d'objet. Les lignes vides sont ignorées. Chaque itération
+de ce générateur produit un objet.
 
 Pour plus d'informations, consultez la documentation des fonctions et les démos
 dans le dépôt de code source.
@@ -76,20 +76,20 @@ python demos/demo_read_no_paths.py
 
 ## ENGLISH
 
-This library writes Python object representations in a text file and reads the
-file to recreate the objects. An object representation is a string returned by
-function `repr`.
+This library writes object representations in a text file and reads the file to
+recreate the objects. An object representation is a string returned by function
+`repr`.
 
 ### Content
 
-Function `write_reprs` writes the representations of Python objects in a text
-file. Each line in the file is an object representation. If the specified file
-already exists, this function overwrites it.
+Function `write_reprs` writes object representations in a text file. Each line
+in the file is an object representation. If the specified file already exists,
+this function overwrites it.
 
-Generator `read_reprs` reads a text file that contains the representations of
-Python objects in order to recreate those objects. Each line in the file must
-be an object representation. Empty lines are ignored. Each iteration of this
-generator yields one object.
+Generator `read_reprs` reads a text file that contains object representations
+to recreate the objects. Each line in the file must be an object
+representation. Empty lines are ignored. Each iteration of this generator
+yields one object.
 
 For more information, consult the functions' documentation and the demos in the
 source code repository.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ fichier texte. Chaque ligne du fichier est une représentation d'objet. Si le
 fichier spécifié existe déjà, cette fonction l'écrase.
 
 Le générateur `read_reprs` lit un fichier texte contenant des représentations
-d'objet Python dans le but de recréer ces objets. Chaque ligne du fichier doit
+d'objets Python dans le but de recréer ces objets. Chaque ligne du fichier doit
 être une représentation d'objet. Les lignes vides sont ignorées. Chaque
 itération de ce générateur produit un objet.
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ importation. C'est le cas des paquets standards et installés. Pour les classes
 d'autres sources, il faut inclure le chemin du dossier parent de leur paquet ou
 module dans la liste `sys.path`. Si des chemins sont fournis au générateur
 `read_reprs`, il les ajoute à `sys.path`, effectue les importations et enlève
-les chemins ajoutés de `sys.path`. L'utilisateur peut aussi modifier lui-même
-`sys.path` et ne pas fournir de chemins.
+les chemins ajoutés de `sys.path`. Si l'utilisateur modifie lui-même
+`sys.path`, il ne devrait pas fournir de chemins à `read_reprs`.
 
 Cependant, si un paquet ou module a été importé avant que `read_reprs` le
 fasse, inclure son chemin parent dans `sys.path` n'est pas nécessaire. Le
@@ -101,12 +101,12 @@ type. For this purpose, the user must provide the necessary import statements
 to `read_reprs` as character strings.
 
 The imported classes' package or module must be accessible for importation. It
-is already the case for standard and installed packages. For classes from other
+is the case for standard and installed packages. For classes from other
 sources, the path to their package's or module's parent directory must be
 included in list `sys.path`. If paths are provided to generator `read_reprs`,
 it adds them to `sys.path`, performs the imports and removes the added paths
-from `sys.path`. The user can also modify `sys.path` themself and not provide
-any path.
+from `sys.path`. If, instead, you modify sys.path out of this generator, you
+should not provide any path to `read_reprs`.
 
 However, if a package or module has been imported before `read_reprs` does so,
 including its parent path in `sys.path` is not required. Dictionary

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ is the case for standard and installed packages. For classes from other
 sources, the path to their package's or module's parent directory must be
 included in list `sys.path`. If paths are provided to generator `read_reprs`,
 it adds them to `sys.path`, performs the imports and removes the added paths
-from `sys.path`. If, instead, you modify yourself `sys.path`, you should not
-provide any path to `read_reprs`.
+from `sys.path`. If, instead, you modify `sys.path` yourself, you should not
+provide paths to `read_reprs`.
 
 However, if a package or module has been imported before `read_reprs` does so,
 including its parent path in `sys.path` is not required. Dictionary

--- a/demos/demo_read_no_paths.py
+++ b/demos/demo_read_no_paths.py
@@ -18,8 +18,8 @@ with SysPathBundle(paths):
 		read_reprs
 
 	# Classes Ajxo and Point are not required in this script.
-	# Importing them ensures their presence in sys.modules.
-	# Thus, the same import statements will work in read_reprs
+	# The next import statements include demo_package and point in sys.modules.
+	# This ensures that identical import statements will work in read_reprs
 	# even though that function will not modify sys.path.
 	from demo_package import\
 		Ajxo
@@ -41,6 +41,7 @@ importations = [
 	"from pathlib import PosixPath, WindowsPath"
 ]
 
+# No paths will be added to sys.path.
 obj_generator = read_reprs(obj_path, importations)
 
 print("Objects read:")

--- a/demos/demo_read_no_paths.py
+++ b/demos/demo_read_no_paths.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+import sys
+from syspathmodif import\
+	SysPathBundle
+
+_LOCAL_DIR = Path(__file__).parent.resolve()
+_REPO_ROOT = _LOCAL_DIR.parent
+
+paths = (
+	# For Ajxo's package
+	_REPO_ROOT,
+	# For Point's module
+	_REPO_ROOT/"demo_package"
+)
+
+with SysPathBundle(paths):
+	from repr_rw import\
+		read_reprs
+
+	# Classes Ajxo and Point are not required in this script.
+	# Importing them ensures their presence in sys.modules.
+	# Thus, the same import statements will work in read_reprs
+	# even though that function will not modify sys.path.
+	from demo_package import\
+		Ajxo
+	from point import\
+		Point
+
+del paths
+
+
+obj_path = _LOCAL_DIR/"objects.txt"
+
+if not obj_path.exists():
+	print("Run demos/demo_write.py to generate the file that this script needs.\n")
+	sys.exit(1)
+
+importations = [
+	"from demo_package import Ajxo",
+	"from point import Point",
+	"from pathlib import PosixPath, WindowsPath"
+]
+
+obj_generator = read_reprs(obj_path, importations)
+
+print("Objects read:")
+for obj in obj_generator:
+	print(f"{obj} {type(obj)}")

--- a/demos/demo_read_no_paths.py
+++ b/demos/demo_read_no_paths.py
@@ -19,7 +19,7 @@ with SysPathBundle(paths):
 
 	# Classes Ajxo and Point are not required in this script.
 	# The next import statements include demo_package and point in sys.modules.
-	# This ensures that identical import statements will work in read_reprs
+	# This ensures that they will be avialabe in read_reprs
 	# even though that function will not modify sys.path.
 	from demo_package import\
 		Ajxo

--- a/repr_rw/repr_rw.py
+++ b/repr_rw/repr_rw.py
@@ -30,10 +30,10 @@ def _raise_import_statement_value_error(importation):
 
 def read_reprs(file_path, importations=None, paths=None):
 	"""
-	If a text file contains the representation of Python objects, this
-	generator can read it to recreate those objects. Each line in the file
-	must be a string returned by function repr. Empty lines are ignored. Each
-	iteration of this generator yields one object.
+	If a text file contains object representations, this generator can read it
+	to recreate the objects. Each line in the file must be a string returned by
+	function repr. Empty lines are ignored. Each iteration of this generator
+	yields one object.
 
 	Recreating objects requires to import their class unless they are of a
 	built-in type. For this purpose, the user must provide the necessary import
@@ -45,8 +45,7 @@ def read_reprs(file_path, importations=None, paths=None):
 	sources, the path to their package's or module's parent directory must be
 	included in list sys.path. If paths are provided to this generator, it adds
 	them to sys.path, performs the imports and removes the paths from sys.path.
-	If, instead, you modify sys.path out of this generator, you should not
-	provide any path.
+	If, instead, you modify sys.path yourself, you should not provide paths.
 
 	Args:
 		file_path (str or pathlib.Path): the path to a text file that contains

--- a/repr_rw/repr_rw.py
+++ b/repr_rw/repr_rw.py
@@ -42,7 +42,7 @@ def read_reprs(file_path, importations=None, paths=None):
 
 	The imported classes' package or module must be accessible for importation.
 	It is already the case for standard and installed packages. For classes
-	from other sources, you need to include the path to its package's or
+	from other sources, you need to include the path to their package's or
 	module's parent directory in list sys.path. If you provide the required
 	paths to this generator, it will add them to sys.path, perform the imports
 	and remove the paths from sys.path. If, instead, you choose to handle the
@@ -64,7 +64,7 @@ def read_reprs(file_path, importations=None, paths=None):
 			not exist.
 		ImportError: if an import statement is incorrect.
 		ModuleNotFoundError: if an imported class' module or package cannot
-			be found. An item in argument paths may be incorrect.
+			be found.
 		NameError: if a required class was not imported.
 		TypeError: if argument file_path or an item in argument paths is not
 			of type str or pathlib.Path.

--- a/repr_rw/repr_rw.py
+++ b/repr_rw/repr_rw.py
@@ -47,6 +47,12 @@ def read_reprs(file_path, importations=None, paths=None):
 	them to sys.path, performs the imports and removes the paths from sys.path.
 	If, instead, you modify sys.path yourself, you should not provide paths.
 
+	However, if a package or module has been imported before this generator
+	does so, including its parent path in sys.path is not required. Dictionary
+	sys.modules stores imported packages and modules for reuse, which makes
+	them available in all modules. Be careful when benefitting from this
+	feature. Otherwise, this generator may raise a ModuleNotFoundError.
+
 	Args:
 		file_path (str or pathlib.Path): the path to a text file that contains
 			object representations.

--- a/repr_rw/repr_rw.py
+++ b/repr_rw/repr_rw.py
@@ -36,17 +36,17 @@ def read_reprs(file_path, importations=None, paths=None):
 	iteration of this generator yields one object.
 
 	Recreating objects requires to import their class unless they are of a
-	built-in type. For this purpose, you need to provide the necessary import
+	built-in type. For this purpose, the user must provide the necessary import
 	statements as character strings. All import statements must match regular
 	expression "from .+ import .+".
 
 	The imported classes' package or module must be accessible for importation.
-	It is already the case for standard and installed packages. For classes
-	from other sources, you need to include the path to their package's or
-	module's parent directory in list sys.path. If you provide the required
-	paths to this generator, it will add them to sys.path, perform the imports
-	and remove the paths from sys.path. If, instead, you choose to handle the
-	paths out of this generator, you should not provide any path.
+	It is the case for standard and installed packages. For classes from other
+	sources, the path to their package's or module's parent directory must be
+	included in list sys.path. If paths are provided to this generator, it adds
+	them to sys.path, performs the imports and removes the paths from sys.path.
+	If, instead, you modify sys.path out of this generator, you should not
+	provide any path.
 
 	Args:
 		file_path (str or pathlib.Path): the path to a text file that contains

--- a/setup.py
+++ b/setup.py
@@ -15,20 +15,20 @@ def _make_descriptions():
 	en_title = "## ENGLISH"
 
 	fr_index = readme_content.index(fr_title)
-	fr_dependencies_index = readme_content.index("### Dépendances")
+	fr_end_index = readme_content.index("#### Importation")
 
 	en_index = readme_content.index(en_title)
 	en_desc_index = en_index + len(en_title)
 	en_content_index = readme_content.index("### Content", en_desc_index)
-	en_dependencies_index = readme_content.index("### Dependencies", en_index)
+	en_end_index = readme_content.index("#### Importing", en_index)
 
 	short_description = readme_content[en_desc_index: en_content_index]
 	short_description = short_description.replace(_NEW_LINE, " ")
 	short_description = short_description.replace("`", "")
 	short_description = short_description.strip()
 
-	long_description = readme_content[fr_index: fr_dependencies_index]\
-		+ readme_content[en_index:en_dependencies_index].rstrip()
+	long_description = readme_content[fr_index: fr_end_index]\
+		+ readme_content[en_index:en_end_index].rstrip()
 
 	return short_description, long_description
 


### PR DESCRIPTION
`README.md` explains how importing a module is possible while its parent path is not in `sys.path`. A new demo proves that works.