### PR TITLE
`syspathmodif` version incremented to `1.4.0`

### DIFF
--- a/.github/workflows/test_pypi_package_build.py
+++ b/.github/workflows/test_pypi_package_build.py
@@ -13,6 +13,6 @@ repo_root = Path(__file__).resolve().parents[2]
 
 system(f"python3 {repo_root}/setup.py sdist")
 
-latest_dist = next((repo_root/"dist").glob("repr_rw-*.tar.gz"))
+src_dist = next((repo_root/"dist").glob("repr_rw-*.tar.gz"))
 
-system(f"pip3 install --no-cache-dir {latest_dist}")
+system(f"pip3 install --no-cache-dir {src_dist}")

--- a/README.md
+++ b/README.md
@@ -122,8 +122,9 @@ Otherwise, `read_reprs` may raise a `ModuleNotFoundError`.
 
 Library `syspathmodif`, a dependency of `repr_rw`, offers function
 `sm_contains`, which indicates whether `sys.modules` contains the module or
-package given as argument. If `sm_contains` returns `True`, you can omit
-including the concerned module's or package's parent path in `sys.path`.
+package whose name is given as argument. If `sm_contains` returns `True`, you
+can omit including the concerned module's or package's parent path in
+`sys.path`.
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ réutilisation, ce qui les rend importables dans tous les modules. Soyez prudent
 en profitant de cette fonctionnalité. Autrement, `read_reprs` risque de lever
 une exception `ModuleNotFoundError`.
 
+La bibliothèque `syspathmodif`, une dépendance de `repr_rw`, offre la fonction
+`sm_contains`, qui indique si `sys.modules` contient le module ou paquet dont
+le nom est donné en argument. Si `sm_contains` renvoie vrai (`True`), on peut
+omettre d'inclure le chemin parent du module ou paquet concerné dans
+`sys.path`.
+
 ### Dépendances
 
 Installez les dépendances avec cette commande.
@@ -113,6 +119,11 @@ executed, including its parent path in `sys.path` is not required. Dictionary
 `sys.modules` stores imported modules and packages for reuse, which makes them
 importable in all modules. Be careful when benefitting from this feature.
 Otherwise, `read_reprs` may raise a `ModuleNotFoundError`.
+
+Library `syspathmodif`, a dependency of `repr_rw`, offers function
+`sm_contains`, which indicates whether `sys.modules` contains the module or
+package given as argument. If `sm_contains` returns `True`, you can omit
+including the concerned module's or package's parent path in `sys.path`.
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ pip install -r requirements.txt
 ### Démos
 
 Le script `demo_write.py` montre comment utiliser la fonction `write_reprs`. Il
-faut l'exécuter en premier, car il produit un fichier dont `demo_read.py` a
-besoin.
+faut l'exécuter en premier, car il produit un fichier dont les démos de lecture
+ont besoin.
 
 ```
 python demos/demo_write.py
@@ -136,7 +136,7 @@ pip install -r requirements.txt
 ### Demos
 
 Script `demo_write.py` shows how to use function `write_reprs`. It must be
-executed first because it makes a file that `demo_read.py` needs.
+executed first because it makes a file that the reading demos need.
 
 ```
 python demos/demo_write.py

--- a/README.md
+++ b/README.md
@@ -26,18 +26,18 @@ Recréer des objets requiert d'importer leur classe sauf s'ils sont d'un type
 natif (*built-in*). À cette fin, il faut fournir à `read_reprs` les
 instructions d'importation nécessaires en chaînes de caractères.
 
-Le paquet ou module des classes importées doit être accessible pour
-importation. C'est le cas des paquets standards et installés. Pour les classes
-provenant d'autres sources, il faut inclure le chemin du dossier parent de leur
-paquet ou module dans la liste `sys.path`. Si des chemins sont fournis au
-générateur `read_reprs`, il les ajoute à `sys.path`, effectue les importations
-puis enlève les chemins ajoutés de `sys.path`. Si l'utilisateur modifie
-lui-même `sys.path`, il ne devrait pas fournir de chemins à `read_reprs`.
+Le module ou paquet des classes importées doit être importable. C'est le cas
+des paquets standards et installés. Pour les classes provenant d'autres
+sources, il faut inclure le chemin du dossier parent de leur module ou paquet
+dans la liste `sys.path`. Si des chemins sont fournis au générateur
+`read_reprs`, il les ajoute à `sys.path`, effectue les importations puis enlève
+les chemins ajoutés de `sys.path`. Si l'utilisateur modifie lui-même
+`sys.path`, il ne devrait pas fournir de chemins à `read_reprs`.
 
-Cependant, si un paquet ou module a été importé avant que `read_reprs` le
-fasse, inclure son chemin parent dans `sys.path` n'est pas nécessaire. Le
-dictionnaire `sys.modules` conserve les paquets et modules importés pour
-réutilisation, ce qui les rend disponibles dans tous les modules. Soyez prudent
+Cependant, si un module ou paquet a été importé avant l'exécution de
+`read_reprs`, inclure son chemin parent dans `sys.path` n'est pas nécessaire.
+Le dictionnaire `sys.modules` conserve les modules et paquets importés pour
+réutilisation, ce qui les rend importables dans tous les modules. Soyez prudent
 en profitant de cette fonctionnalité. Autrement, `read_reprs` risque de lever
 une exception `ModuleNotFoundError`.
 
@@ -100,18 +100,18 @@ Recreating objects requires to import their class unless they are of a built-in
 type. For this purpose, the user must provide the necessary import statements
 to `read_reprs` as character strings.
 
-The imported classes' package or module must be accessible for importation. It
-is the case for standard and installed packages. For classes from other
-sources, the path to their package's or module's parent directory must be
-included in list `sys.path`. If paths are provided to generator `read_reprs`,
-it adds them to `sys.path`, performs the imports and removes the added paths
-from `sys.path`. If, instead, you modify `sys.path` yourself, you should not
-provide paths to `read_reprs`.
+The imported classes' module or package must be importable. It is the case for
+standard and installed packages. For classes from other sources, the path to
+their module's or package's parent directory must be included in list
+`sys.path`. If paths are provided to generator `read_reprs`, it adds them to
+`sys.path`, performs the imports and removes the added paths from `sys.path`.
+If, instead, you modify `sys.path` yourself, you should not provide paths to
+`read_reprs`.
 
-However, if a package or module has been imported before `read_reprs` does so,
-including its parent path in `sys.path` is not required. Dictionary
-`sys.modules` stores imported packages and modules for reuse, which makes them
-available in all modules. Be careful when benefitting from this feature.
+However, if a module or package has been imported before `read_reprs` is
+executed, including its parent path in `sys.path` is not required. Dictionary
+`sys.modules` stores imported modules and packages for reuse, which makes them
+importable in all modules. Be careful when benefitting from this feature.
 Otherwise, `read_reprs` may raise a `ModuleNotFoundError`.
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ReprRW
+# repr_rw
 
 ## FRANÇAIS
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ une exception `ModuleNotFoundError`.
 La bibliothèque `syspathmodif`, une dépendance de `repr_rw`, offre la fonction
 `sm_contains`, qui indique si `sys.modules` contient le module ou paquet dont
 le nom est donné en argument. Si `sm_contains` renvoie vrai (`True`), on peut
-omettre d'inclure le chemin parent du module ou paquet concerné dans
+importer le module ou paquet concerné sans ajouter son chemin parent à
 `sys.path`.
 
 ### Dépendances
@@ -123,7 +123,7 @@ Otherwise, `read_reprs` may raise a `ModuleNotFoundError`.
 Library `syspathmodif`, a dependency of `repr_rw`, offers function
 `sm_contains`, which indicates whether `sys.modules` contains the module or
 package whose name is given as argument. If `sm_contains` returns `True`, you
-can omit including the concerned module's or package's parent path in
+can import the concerned module or package without adding its parent path to
 `sys.path`.
 
 ### Dependencies

--- a/demo_package/__init__.py
+++ b/demo_package/__init__.py
@@ -1,5 +1,7 @@
 from .ajxo import Ajxo
 from .point import Point
 
-# This package does not declare __all__ because the
-# reading demo needs modules ajxo and point to be public.
+__all__ = [
+	Ajxo.__name__,
+	Point.__name__
+]

--- a/demos/demo_read_no_paths.py
+++ b/demos/demo_read_no_paths.py
@@ -17,14 +17,11 @@ with SysPathBundle(paths):
 	from repr_rw import\
 		read_reprs
 
-	# Classes Ajxo and Point are not required in this script.
 	# The next import statements include demo_package and point in sys.modules.
 	# This ensures that they will be avialabe in read_reprs
 	# even though that function will not modify sys.path.
-	from demo_package import\
-		Ajxo
-	from point import\
-		Point
+	import demo_package
+	import point
 
 del paths
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-syspathmodif==1.3.1
+syspathmodif==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -11,24 +11,24 @@ def _make_descriptions():
 	with open("README.md", _MODE_R, encoding=_ENCODING_UTF8) as readme_file:
 		readme_content = readme_file.read()
 
-	fr_title = "## FRANÇAIS"
-	en_title = "## ENGLISH"
+	title_fr = "## FRANÇAIS"
+	title_en = "## ENGLISH"
 
-	fr_index = readme_content.index(fr_title)
-	fr_end_index = readme_content.index("#### Importation")
+	index_fr = readme_content.index(title_fr)
+	index_end_fr = readme_content.index("#### Importation")
 
-	en_index = readme_content.index(en_title)
-	en_desc_index = en_index + len(en_title)
-	en_content_index = readme_content.index("### Content", en_desc_index)
-	en_end_index = readme_content.index("#### Importing", en_index)
+	index_en = readme_content.index(title_en)
+	index_desc_en = index_en + len(title_en)
+	index_desc_end_en = readme_content.index("### Content", index_desc_en)
+	index_end_en = readme_content.index("#### Importing", index_desc_end_en)
 
-	short_description = readme_content[en_desc_index: en_content_index]
+	short_description = readme_content[index_desc_en: index_desc_end_en]
 	short_description = short_description.replace(_NEW_LINE, " ")
 	short_description = short_description.replace("`", "")
 	short_description = short_description.strip()
 
-	long_description = readme_content[fr_index: fr_end_index]\
-		+ readme_content[en_index:en_end_index].rstrip()
+	long_description = readme_content[index_fr: index_end_fr]\
+		+ readme_content[index_en:index_end_en].rstrip()
 
 	return short_description, long_description
 


### PR DESCRIPTION
Version `1.4.0` offers function `sm_contains`, which indicates whether `sys.modules` contains the module or package whose name is given as argument. If `sm_contains` returns `True`, you can import the concerned module or package without adding its parent path to `sys.path`.