### PR TITLE
Library `syspathmodif` upgraded to version `1.5.0`

### DIFF
--- a/demos/demo_read.py
+++ b/demos/demo_read.py
@@ -1,14 +1,14 @@
 from pathlib import Path
 import sys
 from syspathmodif import\
-	sp_append,\
+	sp_prepend,\
 	sp_remove,\
 	SysPathBundle
 
 _LOCAL_DIR = Path(__file__).parent.resolve()
 _REPO_ROOT = _LOCAL_DIR.parent
 
-sp_append(_REPO_ROOT)
+sp_prepend(_REPO_ROOT)
 from repr_rw import\
 	read_reprs
 sp_remove(_REPO_ROOT)

--- a/demos/demo_write.py
+++ b/demos/demo_write.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 from syspathmodif import\
 	SysPathBundle,\
-	sp_append,\
+	sp_prepend,\
 	sp_remove
 
 _LOCAL_DIR = Path(__file__).parent.resolve()
 _REPO_ROOT = _LOCAL_DIR.parent
 
-sp_append(_REPO_ROOT)
+sp_prepend(_REPO_ROOT)
 from demo_package import\
 	Ajxo,\
 	Point

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-syspathmodif==1.5.0
+syspathmodif>=1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-syspathmodif==1.4.0
+syspathmodif==1.5.0


### PR DESCRIPTION
* Requirement: `syspathmodif>=1.5.0`
* All occurrences of function `sp_append` were replaced with `sp_prepend`.